### PR TITLE
Merge: beads fork scaffold (PR #8) with conflict resolution

### DIFF
--- a/.agents/rules/use-prs.md
+++ b/.agents/rules/use-prs.md
@@ -1,0 +1,5 @@
+---
+trigger: always_on
+---
+
+Never use --no-verify with any git command. Never commit directly to master. Always create a feature branch. All changes reach master through PRs only.

--- a/cmd/chum/main.go
+++ b/cmd/chum/main.go
@@ -21,6 +21,7 @@ import (
 	tclient "go.temporal.io/sdk/client"
 
 	"github.com/antigravity-dev/chum/internal/api"
+	"github.com/antigravity-dev/chum/internal/beadsfork"
 	"github.com/antigravity-dev/chum/internal/config"
 	"github.com/antigravity-dev/chum/internal/graph"
 	"github.com/antigravity-dev/chum/internal/matrix"
@@ -431,6 +432,10 @@ func main() {
 	dev := flag.Bool("dev", false, "use text log format (default is JSON)")
 	disableAnthropic := flag.Bool("disable-anthropic", false, "remove Anthropic/Claude providers from config and exit")
 	setTickInterval := flag.String("set-tick-interval", "", "set [general].tick_interval in config (e.g. 2m) and exit")
+	enableBeadsFork := flag.Bool("enable-beads-fork", false, "mirror POST /tasks creates to local Beads fork scaffold")
+	beadsForkWorkdir := flag.String("beads-fork-workdir", "", "working directory for bd mirror (default: directory containing --config)")
+	beadsForkBinary := flag.String("beads-fork-binary", beadsfork.DefaultBinary, "bd binary to use for mirror")
+	beadsForkPinnedVersion := flag.String("beads-fork-pinned-version", beadsfork.DefaultPinnedVersion, "expected bd version for mirror")
 	const defaultFallbackModel = "gpt-5.3-codex"
 	fallbackModel := flag.String("fallback-model", defaultFallbackModel, "fallback chief model used with -disable-anthropic")
 	flag.Parse()
@@ -471,6 +476,36 @@ func main() {
 	logger = configureLogger(cfg.General.LogLevel, *dev)
 	slog.SetDefault(logger)
 
+	var taskMirror api.TaskMirror
+	if *enableBeadsFork {
+		mirrorWorkDir := strings.TrimSpace(*beadsForkWorkdir)
+		if mirrorWorkDir == "" {
+			mirrorWorkDir = filepath.Dir(*configPath)
+		}
+		mirrorWorkDir = config.ExpandHome(mirrorWorkDir)
+
+		mirrorClient, mirrorErr := beadsfork.NewClient(beadsfork.Options{
+			Binary:        strings.TrimSpace(*beadsForkBinary),
+			WorkDir:       mirrorWorkDir,
+			PinnedVersion: strings.TrimSpace(*beadsForkPinnedVersion),
+		})
+		if mirrorErr != nil {
+			logger.Error("failed to initialize beads fork mirror client", "error", mirrorErr)
+			os.Exit(1)
+		}
+		if checkErr := mirrorClient.CheckPinnedVersion(context.Background()); checkErr != nil {
+			logger.Error("beads fork mirror version check failed", "error", checkErr, "hint", "use --beads-fork-pinned-version to override")
+			os.Exit(1)
+		}
+
+		taskMirror = api.NewBeadsForkTaskMirror(mirrorClient)
+		logger.Info("beads fork mirror enabled",
+			"workdir", mirrorWorkDir,
+			"binary", strings.TrimSpace(*beadsForkBinary),
+			"pinned_version", strings.TrimSpace(*beadsForkPinnedVersion),
+		)
+	}
+
 	// Open store
 	dbPath := config.ExpandHome(cfg.General.StateDB)
 	st, err := store.Open(dbPath)
@@ -491,7 +526,7 @@ func main() {
 	dag := graph.NewDAG(st.DB())
 	if schemaErr := dag.EnsureSchema(context.Background()); schemaErr != nil {
 		logger.Error("failed to ensure graph schema", "error", schemaErr)
-		os.Exit(1) //nolint:gocritic // exitAfterDefer: acceptable in main() startup
+		os.Exit(1)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -696,7 +731,9 @@ func main() {
 	}()
 
 	// Start API server
-	apiSrv, err := api.NewServer(cfg, st, dag, logger.With("component", "api"))
+	apiSrv, err := api.NewServerWithOptions(cfg, st, dag, logger.With("component", "api"), api.ServerOptions{
+		TaskMirror: taskMirror,
+	})
 	if err != nil {
 		logger.Error("failed to create api server", "error", err)
 		os.Exit(1)

--- a/docs/development/BEADS_FORK_SCAFFOLD.md
+++ b/docs/development/BEADS_FORK_SCAFFOLD.md
@@ -1,0 +1,102 @@
+# Beads Fork Scaffold (Local-Only)
+
+This scaffold lets CHUM evaluate a fork-first Beads strategy without changing current execution paths.
+
+## What was added
+
+- `internal/beadsfork/client.go`
+  - Isolated `bd` wrapper with fixed local safety flags:
+    - `--no-daemon`
+    - `--no-auto-import`
+    - `--no-auto-flush`
+  - Pinned version check (`DefaultPinnedVersion = 0.56.1`)
+  - Scoped methods for:
+    - `create`
+    - `list`
+    - `show`
+    - `update`
+    - `dep add`
+    - `ready`
+    - `blocked`
+    - `sync --flush-only`
+
+- `internal/beadsfork/client_test.go`
+  - Unit tests for command construction, version pin check, and mixed-output JSON parsing.
+
+- `internal/beadsfork/contract_test.go`
+  - Opt-in real `bd` contract flow in a temp git repo.
+  - Disabled by default; enable with `CHUM_BD_CONTRACT=1`.
+
+- `scripts/dev/beads-fork-smoke.sh`
+  - Runs scaffold tests.
+
+- `scripts/dev/temporal-local.sh`
+  - Starts/stops an isolated Temporal Docker container on `127.0.0.1:8233`.
+
+## Run it
+
+### 1) Unit tests (default)
+
+```bash
+scripts/dev/beads-fork-smoke.sh
+```
+
+### 2) Real `bd` contract tests (opt-in)
+
+```bash
+CHUM_BD_CONTRACT=1 scripts/dev/beads-fork-smoke.sh
+```
+
+Optional strict pin in contract mode:
+
+```bash
+CHUM_BD_CONTRACT=1 CHUM_BD_PINNED_VERSION=0.56.1 scripts/dev/beads-fork-smoke.sh
+```
+
+### 3) Enable in CHUM main (flag-gated)
+
+The integration is disabled by default. Enable it explicitly:
+
+```bash
+go run ./cmd/chum \
+  --config chum.toml \
+  --enable-beads-fork \
+  --beads-fork-workdir "$(pwd)" \
+  --beads-fork-pinned-version 0.56.1
+```
+
+Optional binary override:
+
+```bash
+--beads-fork-binary /path/to/bd
+```
+
+## Isolated Temporal (optional)
+
+Start:
+
+```bash
+scripts/dev/temporal-local.sh start
+```
+
+Set env for CHUM shell:
+
+```bash
+eval "$(scripts/dev/temporal-local.sh env)"
+```
+
+Then set your CHUM config to use that host value in `[general].temporal_host_port`
+(for example, in a local copy passed via `--config`).
+
+Status/logs/stop:
+
+```bash
+scripts/dev/temporal-local.sh status
+scripts/dev/temporal-local.sh logs
+scripts/dev/temporal-local.sh stop
+```
+
+## Notes
+
+- Runtime integration is now available but strictly flag-gated (`--enable-beads-fork`).
+- It is a local evaluation harness for deciding fork-vs-native planning strategy.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -26,10 +26,21 @@ type Server struct {
 	startTime      time.Time
 	httpServer     *http.Server
 	authMiddleware *AuthMiddleware
+	taskMirror     TaskMirror
+}
+
+// ServerOptions configures optional API integrations.
+type ServerOptions struct {
+	TaskMirror TaskMirror
 }
 
 // NewServer creates a new API server.
 func NewServer(cfg *config.Config, s *store.Store, dag *graph.DAG, logger *slog.Logger) (*Server, error) {
+	return NewServerWithOptions(cfg, s, dag, logger, ServerOptions{})
+}
+
+// NewServerWithOptions creates a new API server with optional integrations.
+func NewServerWithOptions(cfg *config.Config, s *store.Store, dag *graph.DAG, logger *slog.Logger, opts ServerOptions) (*Server, error) {
 	authMiddleware, err := NewAuthMiddleware(&cfg.API.Security, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize auth middleware: %w", err)
@@ -42,6 +53,7 @@ func NewServer(cfg *config.Config, s *store.Store, dag *graph.DAG, logger *slog.
 		logger:         logger,
 		startTime:      time.Now(),
 		authMiddleware: authMiddleware,
+		taskMirror:     opts.TaskMirror,
 	}, nil
 }
 

--- a/internal/api/handlers_tasks.go
+++ b/internal/api/handlers_tasks.go
@@ -111,17 +111,31 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	var mirroredIssueID string
+	if s.taskMirror != nil {
+		mirrorID, mirrorErr := s.taskMirror.MirrorTaskCreate(ctx, id, req)
+		if mirrorErr != nil {
+			s.logger.Warn("task mirror failed", "task_id", id, "project", req.Project, "error", mirrorErr)
+		} else {
+			mirroredIssueID = mirrorID
+		}
+	}
+
 	s.logger.Info("task created via API", "id", id, "project", req.Project, "priority", req.Priority)
 
 	// Fire async crab review to validate sizing and dependencies
 	s.triggerCrabReview(req.Project, id, req.Title, req.Description)
 
 	w.WriteHeader(http.StatusCreated)
-	writeJSON(w, map[string]any{
+	resp := map[string]any{
 		"id":      id,
 		"status":  req.Status,
 		"project": req.Project,
-	})
+	}
+	if mirroredIssueID != "" {
+		resp["beads_mirror_id"] = mirroredIssueID
+	}
+	writeJSON(w, resp)
 }
 
 // GET /tasks?project=<name>&status=<status> — list tasks

--- a/internal/api/handlers_tasks_test.go
+++ b/internal/api/handlers_tasks_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTaskMirror struct {
+	id      string
+	err     error
+	called  bool
+	taskID  string
+	lastReq CreateTaskRequest
+}
+
+func (f *fakeTaskMirror) MirrorTaskCreate(_ context.Context, taskID string, req CreateTaskRequest) (string, error) {
+	f.called = true
+	f.taskID = taskID
+	f.lastReq = req
+	return f.id, f.err
+}
+
+func TestHandleTaskCreateIncludesBeadsMirrorIDWhenEnabled(t *testing.T) {
+	srv := setupTestServer(t)
+	require.NoError(t, srv.dag.EnsureSchema(t.Context()))
+
+	mirror := &fakeTaskMirror{id: "bd-abc123"}
+	srv.taskMirror = mirror
+
+	body := `{"title":"Mirror me","project":"test-proj","description":"hello","priority":2,"type":"task"}`
+	req := httptest.NewRequest(http.MethodPost, "/tasks", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	srv.handleTaskCreate(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp["id"])
+	require.Equal(t, "bd-abc123", resp["beads_mirror_id"])
+
+	require.True(t, mirror.called)
+	require.Equal(t, "Mirror me", mirror.lastReq.Title)
+	require.Equal(t, "test-proj", mirror.lastReq.Project)
+}
+
+func TestHandleTaskCreateContinuesWhenMirrorFails(t *testing.T) {
+	srv := setupTestServer(t)
+	require.NoError(t, srv.dag.EnsureSchema(t.Context()))
+
+	mirror := &fakeTaskMirror{err: errors.New("mirror failed")}
+	srv.taskMirror = mirror
+
+	body := `{"title":"Mirror fail","project":"test-proj","description":"hello","priority":2,"type":"task"}`
+	req := httptest.NewRequest(http.MethodPost, "/tasks", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	srv.handleTaskCreate(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp["id"])
+	_, hasMirrorID := resp["beads_mirror_id"]
+	require.False(t, hasMirrorID)
+}

--- a/internal/api/task_mirror.go
+++ b/internal/api/task_mirror.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/antigravity-dev/chum/internal/beadsfork"
+)
+
+// TaskMirror mirrors API-created tasks to an external planning system.
+// Implementations must be best-effort safe; failures should not block core task creation.
+type TaskMirror interface {
+	MirrorTaskCreate(ctx context.Context, taskID string, req CreateTaskRequest) (externalID string, err error)
+}
+
+type beadsForkClient interface {
+	Create(ctx context.Context, title string, req beadsfork.CreateRequest) (beadsfork.Issue, error)
+	AddDependency(ctx context.Context, issueID, dependsOnID, depType string) error
+}
+
+// BeadsForkTaskMirror mirrors CHUM task creation into a bd workspace.
+// It keeps an in-memory task-id mapping to attach dependency edges for tasks
+// created during the current server lifetime.
+type BeadsForkTaskMirror struct {
+	client beadsForkClient
+
+	mu          sync.RWMutex
+	taskToIssue map[string]string
+}
+
+// NewBeadsForkTaskMirror builds a mirror backed by the beadsfork scaffold client.
+func NewBeadsForkTaskMirror(client *beadsfork.Client) *BeadsForkTaskMirror {
+	return NewBeadsForkTaskMirrorWithClient(client)
+}
+
+// NewBeadsForkTaskMirrorWithClient allows testing with client fakes.
+func NewBeadsForkTaskMirrorWithClient(client beadsForkClient) *BeadsForkTaskMirror {
+	return &BeadsForkTaskMirror{
+		client:      client,
+		taskToIssue: map[string]string{},
+	}
+}
+
+// MirrorTaskCreate mirrors a newly-created CHUM task into bd.
+func (m *BeadsForkTaskMirror) MirrorTaskCreate(ctx context.Context, taskID string, req CreateTaskRequest) (string, error) {
+	if m == nil || m.client == nil {
+		return "", fmt.Errorf("beads mirror client is not configured")
+	}
+
+	issueType := normalizeBeadsIssueType(req.Type)
+	priority := normalizeBeadsPriority(req.Priority)
+	labels := dedupeLabels(req.Labels, "source:chum", "mirror:beads")
+	if taskID != "" {
+		labels = append(labels, "chum-task:"+taskID)
+	}
+
+	created, err := m.client.Create(ctx, req.Title, beadsfork.CreateRequest{
+		Description: buildBeadsDescription(taskID, req),
+		Priority:    priority,
+		IssueType:   issueType,
+		Labels:      labels,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	m.mu.Lock()
+	if taskID != "" {
+		m.taskToIssue[taskID] = created.ID
+	}
+	m.mu.Unlock()
+
+	// Best-effort dependency mirror for dependencies created in current process lifetime.
+	for _, depTaskID := range req.DependsOn {
+		depTaskID = strings.TrimSpace(depTaskID)
+		if depTaskID == "" {
+			continue
+		}
+		if depIssueID, ok := m.lookup(depTaskID); ok {
+			_ = m.client.AddDependency(ctx, created.ID, depIssueID, "blocks") //nolint:errcheck // best-effort
+		}
+	}
+
+	return created.ID, nil
+}
+
+func (m *BeadsForkTaskMirror) lookup(taskID string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	issueID, ok := m.taskToIssue[taskID]
+	return issueID, ok
+}
+
+func normalizeBeadsIssueType(taskType string) string {
+	switch strings.ToLower(strings.TrimSpace(taskType)) {
+	case "bug", "feature", "task", "epic", "chore", "merge-request":
+		return strings.ToLower(strings.TrimSpace(taskType))
+	default:
+		return "task"
+	}
+}
+
+func normalizeBeadsPriority(priority int) int {
+	if priority < 0 || priority > 4 {
+		return 2
+	}
+	return priority
+}
+
+func dedupeLabels(labels []string, extras ...string) []string {
+	out := make([]string, 0, len(labels)+len(extras))
+	add := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return
+		}
+		if slices.Contains(out, v) {
+			return
+		}
+		out = append(out, v)
+	}
+	for _, label := range labels {
+		add(label)
+	}
+	for _, extra := range extras {
+		add(extra)
+	}
+	return out
+}
+
+func buildBeadsDescription(taskID string, req CreateTaskRequest) string {
+	parts := make([]string, 0, 5)
+	if desc := strings.TrimSpace(req.Description); desc != "" {
+		parts = append(parts, desc)
+	}
+
+	meta := make([]string, 0, 3)
+	if taskID != "" {
+		meta = append(meta, "CHUM Task ID: "+taskID)
+	}
+	if project := strings.TrimSpace(req.Project); project != "" {
+		meta = append(meta, "Project: "+project)
+	}
+	if len(meta) > 0 {
+		parts = append(parts, strings.Join(meta, "\n"))
+	}
+
+	if acceptance := strings.TrimSpace(req.Acceptance); acceptance != "" {
+		parts = append(parts, "Acceptance Criteria:\n"+acceptance)
+	}
+	if design := strings.TrimSpace(req.Design); design != "" {
+		parts = append(parts, "Design Notes:\n"+design)
+	}
+
+	if len(parts) == 0 {
+		return "(mirrored from CHUM /tasks)"
+	}
+	return strings.Join(parts, "\n\n")
+}

--- a/internal/api/task_mirror_test.go
+++ b/internal/api/task_mirror_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antigravity-dev/chum/internal/beadsfork"
+)
+
+type fakeBeadsForkClient struct {
+	createCalls []createCall
+	depCalls    []depCall
+	createdIDs  []string
+}
+
+type createCall struct {
+	title string
+	req   beadsfork.CreateRequest
+}
+
+type depCall struct {
+	issueID     string
+	dependsOnID string
+	depType     string
+}
+
+func (f *fakeBeadsForkClient) Create(_ context.Context, title string, req beadsfork.CreateRequest) (beadsfork.Issue, error) {
+	f.createCalls = append(f.createCalls, createCall{title: title, req: req})
+	if len(f.createdIDs) == 0 {
+		return beadsfork.Issue{ID: "bd-auto"}, nil
+	}
+	id := f.createdIDs[0]
+	f.createdIDs = f.createdIDs[1:]
+	return beadsfork.Issue{ID: id}, nil
+}
+
+func (f *fakeBeadsForkClient) AddDependency(_ context.Context, issueID, dependsOnID, depType string) error {
+	f.depCalls = append(f.depCalls, depCall{
+		issueID:     issueID,
+		dependsOnID: dependsOnID,
+		depType:     depType,
+	})
+	return nil
+}
+
+func TestBeadsForkTaskMirrorMirrorsCreateAndKnownDependencies(t *testing.T) {
+	fake := &fakeBeadsForkClient{
+		createdIDs: []string{"bd-1", "bd-2"},
+	}
+	mirror := NewBeadsForkTaskMirrorWithClient(fake)
+
+	firstReq := CreateTaskRequest{
+		Title:       "First",
+		Description: "first desc",
+		Priority:    3,
+		Type:        "feature",
+		Labels:      []string{"backend"},
+		Project:     "chum",
+	}
+	firstID, err := mirror.MirrorTaskCreate(t.Context(), "chum-111111", firstReq)
+	require.NoError(t, err)
+	require.Equal(t, "bd-1", firstID)
+
+	secondReq := CreateTaskRequest{
+		Title:       "Second",
+		Description: "second desc",
+		Priority:    1,
+		Type:        "docs", // unsupported in bd; should normalize to task
+		Labels:      []string{"docs"},
+		Project:     "chum",
+		DependsOn:   []string{"chum-111111"},
+	}
+	secondID, err := mirror.MirrorTaskCreate(t.Context(), "chum-222222", secondReq)
+	require.NoError(t, err)
+	require.Equal(t, "bd-2", secondID)
+
+	require.Len(t, fake.createCalls, 2)
+	require.Equal(t, "First", fake.createCalls[0].title)
+	require.Equal(t, "feature", fake.createCalls[0].req.IssueType)
+	require.Equal(t, 3, fake.createCalls[0].req.Priority)
+	require.Contains(t, fake.createCalls[0].req.Labels, "source:chum")
+	require.Contains(t, fake.createCalls[0].req.Labels, "mirror:beads")
+	require.Contains(t, fake.createCalls[0].req.Labels, "chum-task:chum-111111")
+
+	require.Equal(t, "Second", fake.createCalls[1].title)
+	require.Equal(t, "task", fake.createCalls[1].req.IssueType)
+
+	require.Len(t, fake.depCalls, 1)
+	require.Equal(t, depCall{
+		issueID:     "bd-2",
+		dependsOnID: "bd-1",
+		depType:     "blocks",
+	}, fake.depCalls[0])
+}

--- a/internal/beadsfork/client.go
+++ b/internal/beadsfork/client.go
@@ -1,0 +1,422 @@
+package beadsfork
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	// DefaultBinary is the default Beads CLI binary.
+	DefaultBinary = "bd"
+	// DefaultPinnedVersion is the target upstream release for the fork scaffold.
+	DefaultPinnedVersion = "0.56.1"
+)
+
+var versionPattern = regexp.MustCompile(`bd version (\S+)`)
+
+// Runner executes external commands.
+type Runner interface {
+	Run(ctx context.Context, dir, name string, args ...string) ([]byte, error)
+}
+
+// ExecRunner uses os/exec to run commands.
+type ExecRunner struct{}
+
+// Run executes a command and returns combined output.
+func (ExecRunner) Run(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	return cmd.CombinedOutput()
+}
+
+// Options configures Client construction.
+type Options struct {
+	Binary              string
+	WorkDir             string
+	PinnedVersion       string
+	Runner              Runner
+	DisableNoDaemon     bool
+	DisableNoAutoImport bool
+	DisableNoAutoFlush  bool
+}
+
+// Client is a local wrapper around bd with fixed safety/isolation defaults.
+type Client struct {
+	binary      string
+	workDir     string
+	pinned      string
+	runner      Runner
+	globalFlags []string
+}
+
+// VersionInfo represents `bd version --json` output.
+type VersionInfo struct {
+	Branch  string `json:"branch"`
+	Build   string `json:"build"`
+	Commit  string `json:"commit"`
+	Version string `json:"version"`
+}
+
+// Dependency represents an issue dependency edge in bd JSON.
+type Dependency struct {
+	IssueID     string `json:"issue_id"`
+	DependsOnID string `json:"depends_on_id"`
+	Type        string `json:"type"`
+}
+
+// Issue is the minimal issue payload CHUM needs for scaffold evaluation.
+type Issue struct {
+	ID                 string       `json:"id"`
+	Title              string       `json:"title"`
+	Description        string       `json:"description,omitempty"`
+	Status             string       `json:"status"`
+	Priority           int          `json:"priority"`
+	IssueType          string       `json:"issue_type"`
+	Labels             []string     `json:"labels,omitempty"`
+	CreatedAt          string       `json:"created_at,omitempty"`
+	UpdatedAt          string       `json:"updated_at,omitempty"`
+	DependencyCount    int          `json:"dependency_count,omitempty"`
+	DependentCount     int          `json:"dependent_count,omitempty"`
+	CommentCount       int          `json:"comment_count,omitempty"`
+	BlockedByCount     int          `json:"blocked_by_count,omitempty"`
+	BlockedBy          []string     `json:"blocked_by,omitempty"`
+	Dependencies       []Dependency `json:"dependencies,omitempty"`
+	AcceptanceCriteria string       `json:"acceptance_criteria,omitempty"`
+	Design             string       `json:"design,omitempty"`
+}
+
+// CreateRequest captures a scoped create surface for the scaffold.
+type CreateRequest struct {
+	Description string
+	Priority    int
+	IssueType   string
+	Labels      []string
+}
+
+// UpdateRequest captures a scoped update surface for the scaffold.
+type UpdateRequest struct {
+	Status   string
+	Priority *int
+	Title    string
+}
+
+// NewClient creates an isolated bd client for local CHUM fork evaluation.
+func NewClient(opts Options) (*Client, error) {
+	workDir := strings.TrimSpace(opts.WorkDir)
+	if workDir == "" {
+		return nil, errors.New("workdir is required")
+	}
+
+	binary := strings.TrimSpace(opts.Binary)
+	if binary == "" {
+		binary = DefaultBinary
+	}
+
+	pinned := strings.TrimSpace(opts.PinnedVersion)
+	if pinned == "" {
+		pinned = DefaultPinnedVersion
+	}
+
+	runner := opts.Runner
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+
+	globalFlags := []string{}
+	if !opts.DisableNoDaemon {
+		globalFlags = append(globalFlags, "--no-daemon")
+	}
+	if !opts.DisableNoAutoImport {
+		globalFlags = append(globalFlags, "--no-auto-import")
+	}
+	if !opts.DisableNoAutoFlush {
+		globalFlags = append(globalFlags, "--no-auto-flush")
+	}
+
+	return &Client{
+		binary:      binary,
+		workDir:     workDir,
+		pinned:      normalizeVersion(pinned),
+		runner:      runner,
+		globalFlags: globalFlags,
+	}, nil
+}
+
+// Version returns the active bd binary version.
+func (c *Client) Version(ctx context.Context) (VersionInfo, error) {
+	out, err := c.runRaw(ctx, "version", "--json")
+	if err != nil {
+		return VersionInfo{}, err
+	}
+
+	var info VersionInfo
+	if payload := extractJSONPayload(out); payload != nil {
+		if parseErr := json.Unmarshal(payload, &info); parseErr == nil && strings.TrimSpace(info.Version) != "" {
+			info.Version = normalizeVersion(info.Version)
+			return info, nil
+		}
+	}
+
+	plain := strings.TrimSpace(string(out))
+	match := versionPattern.FindStringSubmatch(plain)
+	if len(match) < 2 {
+		return VersionInfo{}, fmt.Errorf("parse bd version from output: %s", compactOutput(out))
+	}
+	info.Version = normalizeVersion(match[1])
+	return info, nil
+}
+
+// CheckPinnedVersion validates the active bd binary against the pinned version.
+func (c *Client) CheckPinnedVersion(ctx context.Context) error {
+	info, err := c.Version(ctx)
+	if err != nil {
+		return err
+	}
+	if normalizeVersion(info.Version) != c.pinned {
+		return fmt.Errorf("bd version mismatch: expected %s, got %s", c.pinned, info.Version)
+	}
+	return nil
+}
+
+// Create creates a new issue.
+func (c *Client) Create(ctx context.Context, title string, req CreateRequest) (Issue, error) {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return Issue{}, errors.New("title is required")
+	}
+
+	args := []string{"create", title, "--json"}
+	if desc := strings.TrimSpace(req.Description); desc != "" {
+		args = append(args, "--description", desc)
+	}
+	if req.Priority >= 0 {
+		args = append(args, "--priority", strconv.Itoa(req.Priority))
+	}
+	if typ := strings.TrimSpace(req.IssueType); typ != "" {
+		args = append(args, "--type", typ)
+	}
+	if len(req.Labels) > 0 {
+		args = append(args, "--labels", strings.Join(req.Labels, ","))
+	}
+
+	out, err := c.runRaw(ctx, args...)
+	if err != nil {
+		return Issue{}, err
+	}
+	return decodeSingleIssue(out)
+}
+
+// List returns issues from `bd list`.
+func (c *Client) List(ctx context.Context, limit int) ([]Issue, error) {
+	args := []string{"list", "--json"}
+	if limit > 0 {
+		args = append(args, "--limit", strconv.Itoa(limit))
+	}
+	out, err := c.runRaw(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeIssueList(out)
+}
+
+// Show returns details for one issue.
+func (c *Client) Show(ctx context.Context, issueID string) (Issue, error) {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return Issue{}, errors.New("issue id is required")
+	}
+	out, err := c.runRaw(ctx, "show", "--json", issueID)
+	if err != nil {
+		return Issue{}, err
+	}
+	return decodeSingleIssue(out)
+}
+
+// Update updates scoped fields on an issue.
+func (c *Client) Update(ctx context.Context, issueID string, req UpdateRequest) (Issue, error) {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return Issue{}, errors.New("issue id is required")
+	}
+
+	args := []string{"update", issueID, "--json"}
+	if status := strings.TrimSpace(req.Status); status != "" {
+		args = append(args, "--status", status)
+	}
+	if req.Priority != nil {
+		args = append(args, "--priority", strconv.Itoa(*req.Priority))
+	}
+	if title := strings.TrimSpace(req.Title); title != "" {
+		args = append(args, "--title", title)
+	}
+
+	out, err := c.runRaw(ctx, args...)
+	if err != nil {
+		return Issue{}, err
+	}
+	return decodeSingleIssue(out)
+}
+
+// AddDependency links issueID -> dependsOnID with dependency type.
+func (c *Client) AddDependency(ctx context.Context, issueID, dependsOnID, depType string) error {
+	issueID = strings.TrimSpace(issueID)
+	dependsOnID = strings.TrimSpace(dependsOnID)
+	depType = strings.TrimSpace(depType)
+	if issueID == "" || dependsOnID == "" {
+		return errors.New("issue id and depends-on id are required")
+	}
+	if depType == "" {
+		depType = "blocks"
+	}
+
+	_, err := c.runRaw(ctx, "dep", "add", issueID, dependsOnID, "--type", depType, "--json")
+	return err
+}
+
+// Ready returns unblocked ready issues.
+func (c *Client) Ready(ctx context.Context, limit int) ([]Issue, error) {
+	args := []string{"ready", "--json"}
+	if limit > 0 {
+		args = append(args, "--limit", strconv.Itoa(limit))
+	}
+	out, err := c.runRaw(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeIssueList(out)
+}
+
+// Blocked returns blocked issues.
+func (c *Client) Blocked(ctx context.Context) ([]Issue, error) {
+	out, err := c.runRaw(ctx, "blocked", "--json")
+	if err != nil {
+		return nil, err
+	}
+	return decodeIssueList(out)
+}
+
+// SyncFlushOnly exports DB state to JSONL without git operations.
+func (c *Client) SyncFlushOnly(ctx context.Context) error {
+	_, err := c.runRaw(ctx, "sync", "--flush-only")
+	return err
+}
+
+func (c *Client) runRaw(ctx context.Context, args ...string) ([]byte, error) {
+	fullArgs := make([]string, 0, len(c.globalFlags)+len(args))
+	fullArgs = append(fullArgs, c.globalFlags...)
+	fullArgs = append(fullArgs, args...)
+
+	out, err := c.runner.Run(ctx, c.workDir, c.binary, fullArgs...)
+	if err != nil {
+		return out, fmt.Errorf("%s %s failed: %w (%s)", c.binary, strings.Join(args, " "), err, compactOutput(out))
+	}
+	return out, nil
+}
+
+func decodeSingleIssue(out []byte) (Issue, error) {
+	payload := extractJSONPayload(out)
+	if payload == nil {
+		return Issue{}, fmt.Errorf("missing JSON payload: %s", compactOutput(out))
+	}
+
+	payload = []byte(strings.TrimSpace(string(payload)))
+	if len(payload) == 0 {
+		return Issue{}, fmt.Errorf("empty JSON payload: %s", compactOutput(out))
+	}
+
+	switch payload[0] {
+	case '{':
+		var one Issue
+		if err := json.Unmarshal(payload, &one); err != nil {
+			return Issue{}, fmt.Errorf("decode issue object: %w", err)
+		}
+		return one, nil
+	case '[':
+		var many []Issue
+		if err := json.Unmarshal(payload, &many); err != nil {
+			return Issue{}, fmt.Errorf("decode issue list: %w", err)
+		}
+		if len(many) == 0 {
+			return Issue{}, errors.New("issue list is empty")
+		}
+		return many[0], nil
+	default:
+		return Issue{}, fmt.Errorf("unexpected JSON payload: %s", compactOutput(payload))
+	}
+}
+
+func decodeIssueList(out []byte) ([]Issue, error) {
+	payload := extractJSONPayload(out)
+	if payload == nil {
+		return nil, fmt.Errorf("missing JSON payload: %s", compactOutput(out))
+	}
+
+	var list []Issue
+	if err := json.Unmarshal(payload, &list); err != nil {
+		return nil, fmt.Errorf("decode issue list: %w", err)
+	}
+	return list, nil
+}
+
+func normalizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	return v
+}
+
+func compactOutput(out []byte) string {
+	s := strings.TrimSpace(string(out))
+	if s == "" {
+		return "no output"
+	}
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) > 500 {
+		return s[:500] + "..."
+	}
+	return s
+}
+
+func extractJSONPayload(out []byte) []byte {
+	s := strings.TrimSpace(string(out))
+	if s == "" {
+		return nil
+	}
+	if json.Valid([]byte(s)) {
+		return []byte(s)
+	}
+
+	for i := 0; i < len(s); i++ {
+		if s[i] != '{' && s[i] != '[' {
+			continue
+		}
+
+		candidate := strings.TrimSpace(s[i:])
+		if candidate == "" {
+			continue
+		}
+		if json.Valid([]byte(candidate)) {
+			return []byte(candidate)
+		}
+
+		dec := json.NewDecoder(strings.NewReader(candidate))
+		var v any
+		if err := dec.Decode(&v); err == nil {
+			offset := dec.InputOffset()
+			if offset > 0 && int(offset) <= len(candidate) {
+				prefix := strings.TrimSpace(candidate[:offset])
+				if json.Valid([]byte(prefix)) {
+					return []byte(prefix)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/beadsfork/client_test.go
+++ b/internal/beadsfork/client_test.go
@@ -1,0 +1,156 @@
+package beadsfork
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type runCall struct {
+	dir  string
+	name string
+	args []string
+}
+
+type fakeRunner struct {
+	calls     []runCall
+	responses []fakeResponse
+}
+
+type fakeResponse struct {
+	out []byte
+	err error
+}
+
+func (f *fakeRunner) Run(_ context.Context, dir, name string, args ...string) ([]byte, error) {
+	call := runCall{
+		dir:  dir,
+		name: name,
+		args: append([]string(nil), args...),
+	}
+	f.calls = append(f.calls, call)
+	if len(f.responses) == 0 {
+		return nil, errors.New("unexpected run with no fake response")
+	}
+	resp := f.responses[0]
+	f.responses = f.responses[1:]
+	return resp.out, resp.err
+}
+
+func TestNewClientRequiresWorkDir(t *testing.T) {
+	_, err := NewClient(Options{})
+	require.ErrorContains(t, err, "workdir is required")
+}
+
+func TestCheckPinnedVersionMismatch(t *testing.T) {
+	runner := &fakeRunner{
+		responses: []fakeResponse{
+			{out: []byte(`{"version":"0.49.3"}`)},
+		},
+	}
+	client, err := NewClient(Options{
+		WorkDir:       "/tmp/work",
+		PinnedVersion: "0.56.1",
+		Runner:        runner,
+	})
+	require.NoError(t, err)
+
+	err = client.CheckPinnedVersion(t.Context())
+	require.ErrorContains(t, err, "bd version mismatch")
+	require.Len(t, runner.calls, 1)
+	require.Equal(t, "/tmp/work", runner.calls[0].dir)
+	require.Equal(t, "bd", runner.calls[0].name)
+	require.Equal(t, []string{"--no-daemon", "--no-auto-import", "--no-auto-flush", "version", "--json"}, runner.calls[0].args)
+}
+
+func TestCreateAndReadCallsWithMixedOutput(t *testing.T) {
+	runner := &fakeRunner{
+		responses: []fakeResponse{
+			{
+				out: []byte("warning: beads.role not configured\n{\"id\":\"bd-a1\",\"title\":\"task a\",\"status\":\"open\",\"priority\":1,\"issue_type\":\"task\"}\n"),
+			},
+			{
+				out: []byte("[{\"id\":\"bd-a1\",\"title\":\"task a\",\"status\":\"open\",\"priority\":1,\"issue_type\":\"task\"}]"),
+			},
+			{
+				out: []byte("[{\"id\":\"bd-a1\",\"title\":\"task a\",\"status\":\"open\",\"priority\":1,\"issue_type\":\"task\"}]"),
+			},
+		},
+	}
+	client, err := NewClient(Options{
+		WorkDir: "/tmp/work",
+		Runner:  runner,
+	})
+	require.NoError(t, err)
+
+	created, err := client.Create(t.Context(), "task a", CreateRequest{
+		Description: "d",
+		Priority:    1,
+		IssueType:   "task",
+		Labels:      []string{"alpha", "beta"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "bd-a1", created.ID)
+
+	listed, err := client.List(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	require.Equal(t, "bd-a1", listed[0].ID)
+
+	shown, err := client.Show(t.Context(), "bd-a1")
+	require.NoError(t, err)
+	require.Equal(t, "bd-a1", shown.ID)
+
+	require.Len(t, runner.calls, 3)
+	require.Equal(t, []string{
+		"--no-daemon", "--no-auto-import", "--no-auto-flush",
+		"create", "task a", "--json", "--description", "d", "--priority", "1", "--type", "task", "--labels", "alpha,beta",
+	}, runner.calls[0].args)
+	require.Equal(t, []string{
+		"--no-daemon", "--no-auto-import", "--no-auto-flush",
+		"list", "--json", "--limit", "10",
+	}, runner.calls[1].args)
+	require.Equal(t, []string{
+		"--no-daemon", "--no-auto-import", "--no-auto-flush",
+		"show", "--json", "bd-a1",
+	}, runner.calls[2].args)
+}
+
+func TestSyncFlushOnly(t *testing.T) {
+	runner := &fakeRunner{
+		responses: []fakeResponse{
+			{out: []byte("")},
+		},
+	}
+	client, err := NewClient(Options{
+		WorkDir: "/tmp/work",
+		Runner:  runner,
+	})
+	require.NoError(t, err)
+
+	err = client.SyncFlushOnly(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"--no-daemon", "--no-auto-import", "--no-auto-flush",
+		"sync", "--flush-only",
+	}, runner.calls[0].args)
+}
+
+func TestVersionFallbackParsesPlainOutput(t *testing.T) {
+	runner := &fakeRunner{
+		responses: []fakeResponse{
+			{out: []byte("bd version v0.56.1 (abcdef: HEAD@abcdef)\n")},
+		},
+	}
+	client, err := NewClient(Options{
+		WorkDir: "/tmp/work",
+		Runner:  runner,
+	})
+	require.NoError(t, err)
+
+	info, err := client.Version(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "0.56.1", info.Version)
+}

--- a/internal/beadsfork/contract_test.go
+++ b/internal/beadsfork/contract_test.go
@@ -1,0 +1,125 @@
+package beadsfork
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBDContractScaffoldFlow(t *testing.T) {
+	if os.Getenv("CHUM_BD_CONTRACT") != "1" {
+		t.Skip("set CHUM_BD_CONTRACT=1 to run real bd contract tests")
+	}
+	if _, err := exec.LookPath("bd"); err != nil {
+		t.Skip("bd binary not found in PATH")
+	}
+
+	tmp := t.TempDir()
+	mustRun(t, tmp, "git", "init", "-q")
+	mustRun(t, tmp, "bd", "init")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 40*time.Second)
+	defer cancel()
+
+	pinned := strings.TrimSpace(os.Getenv("CHUM_BD_PINNED_VERSION"))
+	if pinned == "" {
+		detected := detectVersion(ctx, t, tmp)
+		pinned = detected.Version
+	}
+
+	client, err := NewClient(Options{
+		WorkDir:       tmp,
+		PinnedVersion: pinned,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, client.CheckPinnedVersion(ctx))
+
+	b, err := client.Create(ctx, "B (blocker)", CreateRequest{
+		Description: "blocking task",
+		Priority:    1,
+		IssueType:   "task",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, b.ID)
+
+	a, err := client.Create(ctx, "A (blocked)", CreateRequest{
+		Description: "blocked task",
+		Priority:    1,
+		IssueType:   "task",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, a.ID)
+
+	require.NoError(t, client.AddDependency(ctx, a.ID, b.ID, "blocks"))
+
+	listed, err := client.List(ctx, 20)
+	require.NoError(t, err)
+	require.True(t, containsIssue(listed, a.ID))
+	require.True(t, containsIssue(listed, b.ID))
+
+	ready, err := client.Ready(ctx, 20)
+	require.NoError(t, err)
+	require.True(t, containsIssue(ready, b.ID))
+	require.False(t, containsIssue(ready, a.ID))
+
+	blocked, err := client.Blocked(ctx)
+	require.NoError(t, err)
+	require.True(t, containsIssue(blocked, a.ID))
+
+	newPriority := 0
+	updated, err := client.Update(ctx, b.ID, UpdateRequest{
+		Status:   "in_progress",
+		Priority: &newPriority,
+		Title:    "B (in progress)",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "in_progress", updated.Status)
+	require.Equal(t, 0, updated.Priority)
+	require.Equal(t, "B (in progress)", updated.Title)
+
+	shown, err := client.Show(ctx, a.ID)
+	require.NoError(t, err)
+	require.Equal(t, a.ID, shown.ID)
+
+	require.NoError(t, client.SyncFlushOnly(ctx))
+
+	jsonlPath := filepath.Join(tmp, ".beads", "issues.jsonl")
+	data, readErr := os.ReadFile(jsonlPath)
+	require.NoError(t, readErr)
+	require.Contains(t, string(data), a.ID)
+	require.Contains(t, string(data), b.ID)
+}
+
+func detectVersion(ctx context.Context, t *testing.T, dir string) VersionInfo {
+	t.Helper()
+	client, err := NewClient(Options{WorkDir: dir, PinnedVersion: "0.0.0"})
+	require.NoError(t, err)
+	info, err := client.Version(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, info.Version)
+	return info
+}
+
+func mustRun(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "command failed: %s %s\n%s", name, strings.Join(args, " "), string(out))
+}
+
+func containsIssue(issues []Issue, id string) bool {
+	for _, issue := range issues {
+		if issue.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -23,8 +23,16 @@ func setupTestRepo(t *testing.T) string {
 	}
 
 	// Configure git user (required for commits)
-	exec.Command("git", "config", "user.name", "Test User").Dir = tmpDir
-	exec.Command("git", "config", "user.email", "test@example.com").Dir = tmpDir
+	cmd = exec.Command("git", "config", "user.name", "Test User")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to set git user.name: %v", err)
+	}
+	cmd = exec.Command("git", "config", "user.email", "test@example.com")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to set git user.email: %v", err)
+	}
 
 	// Create an initial commit
 	testFile := filepath.Join(tmpDir, "README.md")

--- a/internal/matrix/poller_test.go
+++ b/internal/matrix/poller_test.go
@@ -613,7 +613,7 @@ func TestPollerRunStopsOnContextCancel(t *testing.T) {
 		},
 	}, client, dispatcher, nil)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	poller.Run(ctx)
 }

--- a/internal/store/sprint_test.go
+++ b/internal/store/sprint_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -83,11 +82,11 @@ func TestGetBacklogMorsels(t *testing.T) {
 	defer s.Close()
 
 	dag := graph.NewDAG(s.DB())
-	if err := dag.EnsureSchema(context.Background()); err != nil {
+	if err := dag.EnsureSchema(t.Context()); err != nil {
 		t.Fatalf("EnsureSchema failed: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := dag.CreateTask(ctx, graph.Task{
 		Title:   "Backlog task",
 		Status:  "open",
@@ -112,11 +111,11 @@ func TestGetSprintContext(t *testing.T) {
 	defer s.Close()
 
 	dag := graph.NewDAG(s.DB())
-	if err := dag.EnsureSchema(context.Background()); err != nil {
+	if err := dag.EnsureSchema(t.Context()); err != nil {
 		t.Fatalf("EnsureSchema failed: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sprintContext, err := s.GetSprintContext(ctx, dag, "test-project", 7)
 	if err != nil {
 		t.Fatalf("GetSprintContext failed: %v", err)

--- a/internal/temporal/admin_batch_ops_test.go
+++ b/internal/temporal/admin_batch_ops_test.go
@@ -57,7 +57,7 @@ func assertTerminationOp(t *testing.T, req *workflowservice.StartBatchOperationR
 
 func TestStartDrainAgentWorkflowsStartsSignalBatchOperation(t *testing.T) {
 	svc := &fakeBatchService{}
-	operationID, err := StartDrainAgentWorkflows(context.Background(), svc, "", "WorkflowType = 'ChumAgentWorkflow'")
+	operationID, err := StartDrainAgentWorkflows(t.Context(), svc, "", "WorkflowType = 'ChumAgentWorkflow'")
 	require.NoError(t, err)
 	require.NotEmpty(t, operationID)
 	require.Contains(t, operationID, "chum-admin-drain")
@@ -69,7 +69,7 @@ func TestStartDrainAgentWorkflowsStartsSignalBatchOperation(t *testing.T) {
 
 func TestStartResumeAgentWorkflowsStartsSignalBatchOperation(t *testing.T) {
 	svc := &fakeBatchService{}
-	operationID, err := StartResumeAgentWorkflows(context.Background(), svc, "ns", "ExecutionStatus = 'Running'")
+	operationID, err := StartResumeAgentWorkflows(t.Context(), svc, "ns", "ExecutionStatus = 'Running'")
 	require.NoError(t, err)
 	require.NotEmpty(t, operationID)
 	require.Contains(t, operationID, "chum-admin-resume")
@@ -81,7 +81,7 @@ func TestStartResumeAgentWorkflowsStartsSignalBatchOperation(t *testing.T) {
 
 func TestStartResetAgentWorkflowsStartsResetBatchOperation(t *testing.T) {
 	svc := &fakeBatchService{}
-	operationID, err := StartResetAgentWorkflows(context.Background(), svc, "", "Project = 'api'")
+	operationID, err := StartResetAgentWorkflows(t.Context(), svc, "", "Project = 'api'")
 	require.NoError(t, err)
 	require.NotEmpty(t, operationID)
 	require.Contains(t, operationID, "chum-admin-reset")
@@ -93,7 +93,7 @@ func TestStartResetAgentWorkflowsStartsResetBatchOperation(t *testing.T) {
 
 func TestStartTerminateAgentWorkflowsStartsTerminationBatchOperation(t *testing.T) {
 	svc := &fakeBatchService{}
-	operationID, err := StartTerminateAgentWorkflows(context.Background(), svc, "custom-ns", "CurrentStage = 'running'")
+	operationID, err := StartTerminateAgentWorkflows(t.Context(), svc, "custom-ns", "CurrentStage = 'running'")
 	require.NoError(t, err)
 	require.NotEmpty(t, operationID)
 	require.Contains(t, operationID, "chum-admin-terminate")
@@ -105,9 +105,9 @@ func TestStartTerminateAgentWorkflowsStartsTerminationBatchOperation(t *testing.
 
 func TestStartAgentWorkflowsRejectsMissingQuery(t *testing.T) {
 	svc := &fakeBatchService{}
-	_, err := StartResetAgentWorkflows(context.Background(), svc, "", "   ")
+	_, err := StartResetAgentWorkflows(t.Context(), svc, "", "   ")
 	require.Error(t, err)
 
-	_, err = StartTerminateAgentWorkflows(context.Background(), svc, "", "\t")
+	_, err = StartTerminateAgentWorkflows(t.Context(), svc, "", "\t")
 	require.Error(t, err)
 }

--- a/internal/temporal/calcifier_activities.go
+++ b/internal/temporal/calcifier_activities.go
@@ -327,11 +327,9 @@ func extractScriptContent(output string) string {
 }
 
 func detectScriptLanguage(content string) (lang, ext string) {
-	first := ""
+	first := content
 	if idx := strings.Index(content, "\n"); idx > 0 {
 		first = content[:idx]
-	} else {
-		first = content
 	}
 
 	switch {

--- a/internal/temporal/workflow_test.go
+++ b/internal/temporal/workflow_test.go
@@ -176,7 +176,7 @@ func TestCHUMNotSpawnedOnFailure(t *testing.T) {
 	env.OnWorkflow(ContinuousLearnerWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
 	env.OnWorkflow(TacticalGroomWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
 	// Failure path may spawn planning rescue after escalation.
-	env.OnWorkflow(AutonomousPlanningCeremonyWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
+	env.OnWorkflow(AutonomousPlanningCeremonyWorkflow, mock.Anything, mock.Anything).Return(&TurtlePlanningResult{}, nil).Maybe()
 	env.OnWorkflow(PlanningCeremonyWorkflow, mock.Anything, mock.Anything).Return(&TaskRequest{}, nil).Maybe()
 
 	env.OnActivity(a.AutoFixLintActivity, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
@@ -788,7 +788,7 @@ func TestStepDurationLoggingWhenReviewActivityFails(t *testing.T) {
 
 	env.OnWorkflow(ContinuousLearnerWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
 	env.OnWorkflow(TacticalGroomWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
-	env.OnWorkflow(AutonomousPlanningCeremonyWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
+	env.OnWorkflow(AutonomousPlanningCeremonyWorkflow, mock.Anything, mock.Anything).Return(&TurtlePlanningResult{}, nil).Maybe()
 	env.OnWorkflow(PlanningCeremonyWorkflow, mock.Anything, mock.Anything).Return(&TaskRequest{}, nil).Maybe()
 
 	var outcome OutcomeRecord
@@ -863,7 +863,7 @@ func TestStepDurationLoggingEscalation(t *testing.T) {
 
 	env.OnWorkflow(ContinuousLearnerWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
 	env.OnWorkflow(TacticalGroomWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
-	env.OnWorkflow(AutonomousPlanningCeremonyWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
+	env.OnWorkflow(AutonomousPlanningCeremonyWorkflow, mock.Anything, mock.Anything).Return(&TurtlePlanningResult{}, nil).Maybe()
 	env.OnWorkflow(PlanningCeremonyWorkflow, mock.Anything, mock.Anything).Return(&TaskRequest{}, nil).Maybe()
 
 	var outcome OutcomeRecord

--- a/scripts/dev/beads-fork-smoke.sh
+++ b/scripts/dev/beads-fork-smoke.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "==> Running beads fork scaffold tests"
+echo "    Package: ./internal/beadsfork"
+echo "    Contract tests: ${CHUM_BD_CONTRACT:-0} (set to 1 to enable real bd execution)"
+
+go test ./internal/beadsfork -count=1 -v
+
+echo "==> beads fork scaffold tests completed"

--- a/scripts/dev/temporal-local.sh
+++ b/scripts/dev/temporal-local.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAME="${TEMPORAL_DOCKER_NAME:-chum-temporal-local}"
+IMAGE="${TEMPORAL_IMAGE:-temporalio/auto-setup:1.28.1}"
+HOST_PORT="${TEMPORAL_PORT:-8233}"
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") <start|stop|status|logs|env>
+
+Commands:
+  start   Start isolated Temporal container on 127.0.0.1:${HOST_PORT}
+  stop    Stop and remove container '${NAME}'
+  status  Show container status
+  logs    Tail container logs
+  env     Print env vars to point CHUM to this local Temporal
+
+Environment overrides:
+  TEMPORAL_DOCKER_NAME   Container name (default: ${NAME})
+  TEMPORAL_IMAGE         Docker image (default: ${IMAGE})
+  TEMPORAL_PORT          Host port mapped to container 7233 (default: ${HOST_PORT})
+USAGE
+}
+
+cmd="${1:-status}"
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "docker binary not found in PATH"
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "docker daemon is not reachable; start Docker Desktop/Engine first"
+    exit 1
+  fi
+}
+
+case "$cmd" in
+  start)
+    require_docker
+    if docker ps -a --format '{{.Names}}' | grep -Fxq "$NAME"; then
+      if docker ps --format '{{.Names}}' | grep -Fxq "$NAME"; then
+        echo "Temporal container '${NAME}' already running"
+      else
+        docker start "$NAME" >/dev/null
+        echo "Temporal container '${NAME}' started"
+      fi
+    else
+      docker run -d \
+        --name "$NAME" \
+        -p "${HOST_PORT}:7233" \
+        "$IMAGE" >/dev/null
+      echo "Temporal container '${NAME}' created and started on 127.0.0.1:${HOST_PORT}"
+    fi
+    ;;
+  stop)
+    require_docker
+    if docker ps -a --format '{{.Names}}' | grep -Fxq "$NAME"; then
+      docker rm -f "$NAME" >/dev/null
+      echo "Temporal container '${NAME}' removed"
+    else
+      echo "Temporal container '${NAME}' not found"
+    fi
+    ;;
+  status)
+    require_docker
+    docker ps -a --filter "name=^/${NAME}$" --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+    ;;
+  logs)
+    require_docker
+    docker logs -f "$NAME"
+    ;;
+  env)
+    cat <<ENV
+# CHUM reads Temporal host from [general].temporal_host_port in chum.toml.
+# Use this value when creating a local config copy.
+export CHUM_TEMPORAL_LOCAL_HOST_PORT=127.0.0.1:${HOST_PORT}
+export TEMPORAL_NAMESPACE=default
+ENV
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Merges the beads fork scaffold (PR #8) into master with conflict resolution and lint fixes.

**Conflict resolution:** workflow_test.go — kept master's activity mocks + PR's TurtlePlanningResult return type.

**Lint fixes:** regexpSimplify, context-as-argument, usetesting, errcheck across beadsfork/ and api/ packages.

**Verified:** go build ✅ | golangci-lint ✅ | pre-commit hooks ✅

Closes #8