### PR TITLE
fix: defensive MkdirAll before CLI chdir prevents workspace-missing crashes

### DIFF
--- a/internal/temporal/agent_cli.go
+++ b/internal/temporal/agent_cli.go
@@ -346,6 +346,20 @@ func (a *Activities) runCLI(ctx context.Context, agent, prompt string, cmd *exec
 	cmd.Stderr = &stderr
 	cmd.Stdin = promptFile
 
+	// Defensive: ensure the working directory exists before exec.
+	// /tmp worktrees can disappear after reboots or cleanup jobs; without
+	// this guard the chdir fails and the entire activity errors out.
+	if cmd.Dir != "" {
+		if _, statErr := os.Stat(cmd.Dir); os.IsNotExist(statErr) {
+			activity.GetLogger(ctx).Warn("⚠️ CLI workdir missing — creating it defensively (investigate root cause)",
+				"WorkDir", cmd.Dir, "Agent", agent)
+			if mkErr := os.MkdirAll(cmd.Dir, 0o755); mkErr != nil {
+				promptFile.Close()
+				return CLIResult{}, fmt.Errorf("failed to create workdir %s: %w", cmd.Dir, mkErr)
+			}
+		}
+	}
+
 	if err := cmd.Start(); err != nil {
 		promptFile.Close()
 		return CLIResult{}, fmt.Errorf("failed to start %s: %w", agent, err)


### PR DESCRIPTION
## Problem

When a CLI agent's workdir doesn't exist (e.g. `/tmp` cleared after reboot, stale config pointing at `/tmp/ws`), `exec.Cmd.Start()` fails with:

```
chdir /tmp/ws: no such file or directory
```

This crashed the entire `DecomposeActivity`, causing the crab to escalate to turtle and ultimately fail the workflow.

## Fix

Added defensive `os.MkdirAll` in `runCLI()` before `cmd.Start()`. When the directory doesn't exist, it:
1. Logs a **warning** so the root cause is flagged for investigation
2. Creates the directory so the pipeline continues

This is the single chokepoint for all CLI agent invocations, so the fix covers every activity that runs an LLM agent.

## Context

Seen in production with `review-test-proj-*` workflows imported from elsewhere, using `/tmp/ws` as workspace.