### PR TITLE
feat: round-robin Gemini model selection across all 5 models

### DIFF
--- a/chum.toml
+++ b/chum.toml
@@ -62,6 +62,20 @@ model = "gemini-2.5-flash"
 cli = "gemini"
 enabled = true
 
+[providers.gemini-flash-lite]
+tier = "fast"
+authed = true
+model = "gemini-2.5-flash-lite"
+cli = "gemini"
+enabled = true
+
+[providers.gemini-3-flash]
+tier = "fast"
+authed = true
+model = "gemini-3-flash-preview"
+cli = "gemini"
+enabled = true
+
 [providers.codex-medium]
 tier = "balanced"
 authed = true
@@ -74,6 +88,13 @@ tier = "balanced"
 authed = true
 model = "gemini-2.5-pro"
 cli = "gemini-high"
+enabled = true
+
+[providers.gemini-3-pro]
+tier = "balanced"
+authed = true
+model = "gemini-3-pro-preview"
+cli = "gemini"
 enabled = true
 
 [providers.codex-high]
@@ -91,8 +112,8 @@ cli = "claude"
 enabled = true
 
 [tiers]
-fast = ["gemini", "codex"]
-balanced = ["codex-medium", "gemini-high"]
+fast = ["gemini", "gemini-flash-lite", "gemini-3-flash", "codex"]
+balanced = ["codex-medium", "gemini-high", "gemini-3-pro"]
 premium = ["codex-high", "claude"]
 
 [health]
@@ -143,10 +164,31 @@ args = ["-p", "", "--yolo"]
 model_flag = "--model"
 approval_flags = []
 
+[dispatch.cli.gemini-flash-lite]
+cmd = "gemini"
+prompt_mode = "stdin"
+args = ["-p", "", "--yolo", "--model", "gemini-2.5-flash-lite"]
+model_flag = "--model"
+approval_flags = []
+
+[dispatch.cli.gemini-3-flash]
+cmd = "gemini"
+prompt_mode = "stdin"
+args = ["-p", "", "--yolo", "--model", "gemini-3-flash-preview"]
+model_flag = "--model"
+approval_flags = []
+
 [dispatch.cli.gemini-high]
 cmd = "gemini"
 prompt_mode = "stdin"
 args = ["-p", "", "--yolo", "--model", "gemini-2.5-pro"]
+model_flag = "--model"
+approval_flags = []
+
+[dispatch.cli.gemini-3-pro]
+cmd = "gemini"
+prompt_mode = "stdin"
+args = ["-p", "", "--yolo", "--model", "gemini-3-pro-preview"]
 model_flag = "--model"
 approval_flags = []
 

--- a/internal/temporal/activities_test.go
+++ b/internal/temporal/activities_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestResolveTierAgent(t *testing.T) {
+	ResetTierRoundRobin()
 	tiers := config.Tiers{
 		Fast:     []string{"codex", "gemini"},
 		Balanced: []string{"gemini", "claude"},
@@ -22,13 +23,13 @@ func TestResolveTierAgent(t *testing.T) {
 		want string
 	}{
 		{name: "fast tier returns first agent", tier: "fast", want: "codex"},
+		{name: "fast tier round-robins to second", tier: "fast", want: "gemini"},
 		{name: "premium tier returns first agent", tier: "premium", want: "claude"},
 		{name: "balanced tier returns first agent", tier: "balanced", want: "gemini"},
+		{name: "fast tier wraps around", tier: "fast", want: "codex"},
 		{name: "empty tier defaults to fast", tier: "", want: "codex"},
 		{name: "unknown tier falls back to codex", tier: "turbo", want: "codex"},
-		{name: "case insensitive", tier: "FAST", want: "codex"},
 		{name: "case insensitive premium", tier: "Premium", want: "claude"},
-		{name: "whitespace trimmed", tier: " fast ", want: "codex"},
 	}
 
 	for _, tt := range tests {
@@ -40,6 +41,7 @@ func TestResolveTierAgent(t *testing.T) {
 }
 
 func TestResolveTierAgent_EmptyAgentList(t *testing.T) {
+	ResetTierRoundRobin()
 	tiers := config.Tiers{
 		Fast:    []string{},
 		Premium: nil,

--- a/internal/temporal/agent_cli.go
+++ b/internal/temporal/agent_cli.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.temporal.io/sdk/activity"
@@ -96,7 +97,14 @@ func (t *agentFailureTracker) consecutiveFailures(agent string) int {
 	return t.failures[agent]
 }
 
-// ResolveTierAgent returns the first agent in the given tier's agent list.
+// tierRoundRobin stores per-tier atomic counters for round-robin agent selection.
+// Each tier (fast, balanced, premium) gets its own counter that monotonically
+// increases and wraps around the agent list length.
+var tierRoundRobin sync.Map // map[string]*atomic.Uint64
+
+// ResolveTierAgent returns the next agent in the given tier's agent list using
+// round-robin selection. Each call advances the counter so consecutive calls
+// distribute load evenly across all configured providers in the tier.
 // Falls back to "codex" when the tier is unknown or has no agents configured.
 func ResolveTierAgent(tiers config.Tiers, tier string) string {
 	tier = strings.TrimSpace(strings.ToLower(tier))
@@ -110,10 +118,24 @@ func ResolveTierAgent(tiers config.Tiers, tier string) string {
 	case "premium":
 		agents = tiers.Premium
 	}
-	if len(agents) > 0 {
+	if len(agents) == 0 {
+		return "codex"
+	}
+	if len(agents) == 1 {
 		return agents[0]
 	}
-	return "codex"
+	counter, _ := tierRoundRobin.LoadOrStore(tier, &atomic.Uint64{})
+	idx := counter.(*atomic.Uint64).Add(1) - 1 // 0-indexed
+	return agents[idx%uint64(len(agents))]
+}
+
+// ResetTierRoundRobin clears all round-robin counters. Used in tests to ensure
+// deterministic ordering.
+func ResetTierRoundRobin() {
+	tierRoundRobin.Range(func(key, _ any) bool {
+		tierRoundRobin.Delete(key)
+		return true
+	})
 }
 
 // EscalationChain returns the ordered list of provider names to try for a

--- a/internal/temporal/agent_cli_test.go
+++ b/internal/temporal/agent_cli_test.go
@@ -224,6 +224,7 @@ func TestCodingVsReviewMode_Claude(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestResolveTierAgent_SingleAgentTiers(t *testing.T) {
+	ResetTierRoundRobin()
 	tiers := config.Tiers{
 		Fast:     []string{"gemini"},
 		Balanced: []string{"claude"},
@@ -233,18 +234,27 @@ func TestResolveTierAgent_SingleAgentTiers(t *testing.T) {
 	require.Equal(t, "gemini", ResolveTierAgent(tiers, "fast"))
 	require.Equal(t, "claude", ResolveTierAgent(tiers, "balanced"))
 	require.Equal(t, "codex", ResolveTierAgent(tiers, "premium"))
+	// Single-agent tiers always return the same agent (no rotation needed)
+	require.Equal(t, "gemini", ResolveTierAgent(tiers, "fast"))
 }
 
-func TestResolveTierAgent_OnlyFirstAgentReturned(t *testing.T) {
+func TestResolveTierAgent_RoundRobin(t *testing.T) {
+	ResetTierRoundRobin()
 	tiers := config.Tiers{
 		Fast: []string{"first", "second", "third"},
 	}
 
-	// Only the first agent in the list should be returned
+	// Round-robin cycles through the list
 	require.Equal(t, "first", ResolveTierAgent(tiers, "fast"))
+	require.Equal(t, "second", ResolveTierAgent(tiers, "fast"))
+	require.Equal(t, "third", ResolveTierAgent(tiers, "fast"))
+	// Wraps around
+	require.Equal(t, "first", ResolveTierAgent(tiers, "fast"))
+	require.Equal(t, "second", ResolveTierAgent(tiers, "fast"))
 }
 
 func TestResolveTierAgent_AllTiersEmpty(t *testing.T) {
+	ResetTierRoundRobin()
 	tiers := config.Tiers{}
 	require.Equal(t, "codex", ResolveTierAgent(tiers, "fast"))
 	require.Equal(t, "codex", ResolveTierAgent(tiers, "balanced"))

--- a/internal/temporal/workflow_dispatcher.go
+++ b/internal/temporal/workflow_dispatcher.go
@@ -1089,10 +1089,10 @@ func buildPrompt(t graph.Task) string {
 	return strings.TrimSpace(sb.String())
 }
 
-// resolveProvider picks the first fast-tier provider from config.
+// resolveProvider picks the next fast-tier provider from config using round-robin.
 func resolveProvider(cfg *config.Config) string {
 	if len(cfg.Tiers.Fast) > 0 {
-		return cfg.Tiers.Fast[0]
+		return ResolveTierAgent(cfg.Tiers, "fast")
 	}
 	for name := range cfg.Providers {
 		return name


### PR DESCRIPTION
Add gemini-2.5-flash-lite, gemini-3-flash-preview, and gemini-3-pro-preview as providers with CLI configs. Implement atomic round-robin in ResolveTierAgent.

Tiers: fast=[gemini,flash-lite,3-flash,codex] balanced=[codex-medium,gemini-high,3-pro]