### PR TITLE
fix: apply gofmt formatting to 19 files

### DIFF
--- a/internal/graph/task.go
+++ b/internal/graph/task.go
@@ -30,4 +30,4 @@ type CrossDep struct {
 }
 
 const taskTypeEpic = "epic"
-const taskTypeWhale = "whale"   // epic-level grouping from crab decomposition
+const taskTypeWhale = "whale" // epic-level grouping from crab decomposition

--- a/internal/store/genomes.go
+++ b/internal/store/genomes.go
@@ -22,10 +22,10 @@ type GenomeEntry struct {
 // ProviderGene tracks which provider/model works best for this species.
 // The selfish gene: provider preferences persist across generations of mortal organisms.
 type ProviderGene struct {
-	Provider   string  `json:"provider"`    // e.g. "claude", "codex-spark", "gemini"
+	Provider   string  `json:"provider"` // e.g. "claude", "codex-spark", "gemini"
 	Successes  int     `json:"successes"`
 	Failures   int     `json:"failures"`
-	TotalCost  float64 `json:"total_cost"`  // USD spent through this provider
+	TotalCost  float64 `json:"total_cost"` // USD spent through this provider
 	Generation int     `json:"generation"` // when first observed
 }
 
@@ -48,19 +48,19 @@ func (pg ProviderGene) Fitness() float64 {
 // Species are global and phylogenetic — "go-test-fix" crosses project boundaries.
 // Every organism is mortal. The genome is what persists.
 type Genome struct {
-	Species        string         `json:"species"`
-	ParentSpecies  string         `json:"parent_species"`
-	Patterns       []GenomeEntry  `json:"patterns"`        // DNA: approaches that passed DoD
-	Antibodies     []GenomeEntry  `json:"antibodies"`      // Defensive knowledge from failures
-	Fossils        []GenomeEntry  `json:"fossils"`         // Extinct approaches (failed 3+ times)
-	ProviderGenes  []ProviderGene `json:"provider_genes"` // Selfish genes: which models survive
-	Generation     int            `json:"generation"`
-	Successes      int            `json:"successes"`
-	Failures       int            `json:"failures"`
-	TotalCostUSD   float64        `json:"total_cost_usd"` // Total energy consumed by this species
-	Hibernating    bool           `json:"hibernating"`
-	LastEvolved    *time.Time     `json:"last_evolved,omitempty"`
-	CreatedAt      time.Time      `json:"created_at"`
+	Species       string         `json:"species"`
+	ParentSpecies string         `json:"parent_species"`
+	Patterns      []GenomeEntry  `json:"patterns"`       // DNA: approaches that passed DoD
+	Antibodies    []GenomeEntry  `json:"antibodies"`     // Defensive knowledge from failures
+	Fossils       []GenomeEntry  `json:"fossils"`        // Extinct approaches (failed 3+ times)
+	ProviderGenes []ProviderGene `json:"provider_genes"` // Selfish genes: which models survive
+	Generation    int            `json:"generation"`
+	Successes     int            `json:"successes"`
+	Failures      int            `json:"failures"`
+	TotalCostUSD  float64        `json:"total_cost_usd"` // Total energy consumed by this species
+	Hibernating   bool           `json:"hibernating"`
+	LastEvolved   *time.Time     `json:"last_evolved,omitempty"`
+	CreatedAt     time.Time      `json:"created_at"`
 }
 
 // FossilThreshold is the number of times an antibody must appear before

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -786,4 +786,3 @@ func (s *Store) RecordEscalation(esc ProviderEscalation) error {
 	}
 	return nil
 }
-

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -16,23 +16,23 @@ import (
 // Events form a tree/graph via parent_event_id, capturing LLM calls,
 // tool executions, human feedback, and phase boundaries.
 type GraphTraceEvent struct {
-	EventID         string  `json:"event_id"`
-	ParentEventID   string  `json:"parent_event_id"`
-	SessionID       string  `json:"session_id"`
-	Timestamp       int64   `json:"timestamp"`
-	Depth           int     `json:"depth"`
-	EventType       string  `json:"event_type"` // 'llm_call' | 'tool_call' | 'human_feedback' | 'phase_boundary'
-	Phase           string  `json:"phase"`      // 'plan' | 'execute' | 'review' | 'dod' | 'record'
-	ModelName       string  `json:"model_name,omitempty"`
-	TokensInput     int     `json:"tokens_input,omitempty"`
-	TokensOutput    int     `json:"tokens_output,omitempty"`
-	ToolName        string  `json:"tool_name,omitempty"`
-	ToolSuccess     *bool   `json:"tool_success,omitempty"`
-	HumanMessage    string  `json:"human_message,omitempty"`
-	Reward          float64 `json:"reward"`
-	TerminalReward  *float64 `json:"terminal_reward,omitempty"`
-	IsTerminal      bool    `json:"is_terminal"`
-	Metadata        string  `json:"metadata,omitempty"` // JSON for extensibility
+	EventID        string   `json:"event_id"`
+	ParentEventID  string   `json:"parent_event_id"`
+	SessionID      string   `json:"session_id"`
+	Timestamp      int64    `json:"timestamp"`
+	Depth          int      `json:"depth"`
+	EventType      string   `json:"event_type"` // 'llm_call' | 'tool_call' | 'human_feedback' | 'phase_boundary'
+	Phase          string   `json:"phase"`      // 'plan' | 'execute' | 'review' | 'dod' | 'record'
+	ModelName      string   `json:"model_name,omitempty"`
+	TokensInput    int      `json:"tokens_input,omitempty"`
+	TokensOutput   int      `json:"tokens_output,omitempty"`
+	ToolName       string   `json:"tool_name,omitempty"`
+	ToolSuccess    *bool    `json:"tool_success,omitempty"`
+	HumanMessage   string   `json:"human_message,omitempty"`
+	Reward         float64  `json:"reward"`
+	TerminalReward *float64 `json:"terminal_reward,omitempty"`
+	IsTerminal     bool     `json:"is_terminal"`
+	Metadata       string   `json:"metadata,omitempty"` // JSON for extensibility
 }
 
 // RecordGraphTraceEvent inserts a new trace event into the graph.

--- a/internal/temporal/activities.go
+++ b/internal/temporal/activities.go
@@ -31,11 +31,11 @@ type Activities struct {
 	Tiers       config.Tiers
 	CfgMgr      config.ConfigManager // hot-reloadable config for CLI dispatch
 	DAG         *graph.DAG
-	AST         *astpkg.Parser       // tree-sitter Go parser for codebase context injection
-	Sender      matrix.Sender        // Matrix notification sender (nil = disabled)
-	DefaultRoom string               // Matrix room ID for standard notifications
-	AdminRoom   string               // Matrix room ID for critical escalations (DM)
-	TurtleRoom  string               // Matrix room for turtle deliberation (3-agent conversation)
+	AST         *astpkg.Parser // tree-sitter Go parser for codebase context injection
+	Sender      matrix.Sender  // Matrix notification sender (nil = disabled)
+	DefaultRoom string         // Matrix room ID for standard notifications
+	AdminRoom   string         // Matrix room ID for critical escalations (DM)
+	TurtleRoom  string         // Matrix room for turtle deliberation (3-agent conversation)
 }
 
 // WorktreeDir returns the worktree directory path for a task/explosion pair.
@@ -755,6 +755,7 @@ func fallbackFileList(ctx context.Context, workDir string) string {
 	}
 	return strings.Join(sections, "\n")
 }
+
 // extractJSON finds the first JSON object in text (handles markdown code fences).
 // Applies sanitizeJSON to fix common LLM output issues (invalid escapes, trailing commas).
 func extractJSON(text string) string {

--- a/internal/temporal/agent_cli_test.go
+++ b/internal/temporal/agent_cli_test.go
@@ -408,9 +408,9 @@ type mockConfigManager struct {
 	cfg *config.Config
 }
 
-func (m *mockConfigManager) Get() *config.Config  { return m.cfg }
-func (m *mockConfigManager) Set(*config.Config)    {}
-func (m *mockConfigManager) Reload(string) error   { return nil }
+func (m *mockConfigManager) Get() *config.Config { return m.cfg }
+func (m *mockConfigManager) Set(*config.Config)  {}
+func (m *mockConfigManager) Reload(string) error { return nil }
 
 func TestCLICommandWithModel_ConfigDriven_CodexHigh(t *testing.T) {
 	acts := &Activities{
@@ -558,4 +558,3 @@ func TestCLICommandWithModel_ConfigDriven_DoesNotMutateConfigArgs(t *testing.T) 
 	// Original config args should be untouched
 	require.Equal(t, []string{"exec", "--full-auto"}, cliCfg.Args)
 }
-

--- a/internal/temporal/complexity.go
+++ b/internal/temporal/complexity.go
@@ -21,13 +21,13 @@ func ScoreTaskComplexity(title, prompt, acceptance string, estimateMinutes int) 
 
 	// 2. Keyword-based scoring (up to 40 points)
 	combined := strings.ToLower(title + " " + prompt + " " + acceptance)
-	
+
 	highComplexityKeywords := []string{
-		"architect", "design", "refactor", "rewrite", "migration", 
+		"architect", "design", "refactor", "rewrite", "migration",
 		"security", "concurrency", "race condition", "protocol",
 		"consensus", "authentication", "authorization", "distributed",
 	}
-	
+
 	keywordScore := 0
 	for _, kw := range highComplexityKeywords {
 		if strings.Contains(combined, kw) {
@@ -38,7 +38,7 @@ func ScoreTaskComplexity(title, prompt, acceptance string, estimateMinutes int) 
 		keywordScore = 40
 	}
 	score += keywordScore
-	
+
 	// 3. Length-based scoring (up to 20 points)
 	// Very long prompts usually imply complex requirements.
 	promptLen := len(prompt)

--- a/internal/temporal/complexity_test.go
+++ b/internal/temporal/complexity_test.go
@@ -67,6 +67,6 @@ func TestScoreTaskComplexity(t *testing.T) {
 			if got < tt.wantMin || got > tt.wantMax {
 				t.Errorf("ScoreTaskComplexity() = %v, want between [%v, %v]", got, tt.wantMin, tt.wantMax)
 			}
-		} )
+		})
 	}
 }

--- a/internal/temporal/failure_classifier.go
+++ b/internal/temporal/failure_classifier.go
@@ -100,8 +100,8 @@ func isInfrastructureFailure(lower string) bool {
 		"golangci-lint" + " " + "exit 3",  // config error
 		"golangci-lint" + " " + "exit -1", // signal kill (OOM)
 		"semgrep" + " " + "exit 7",        // config/download error
-		"exit -1",                          // any tool killed by signal (OOM, SIGKILL)
-		"error obtaining vcs status",       // golangci-lint in worktrees
+		"exit -1",                         // any tool killed by signal (OOM, SIGKILL)
+		"error obtaining vcs status",      // golangci-lint in worktrees
 		"command not found",
 		"no such file or directory",
 		"permission denied",

--- a/internal/temporal/json_repair.go
+++ b/internal/temporal/json_repair.go
@@ -4,7 +4,9 @@ import "encoding/json"
 
 // repairTruncatedJSONArray attempts to fix truncated JSON array output from LLMs.
 // When an LLM hits its output token limit, it often produces:
-//   [{"key": "value"}, {"key": "val
+//
+//	[{"key": "value"}, {"key": "val
+//
 // This function tries to close unclosed braces/brackets to make it parseable.
 func repairTruncatedJSONArray(s string) string {
 	if json.Valid([]byte(s)) {

--- a/internal/temporal/learner_activities.go
+++ b/internal/temporal/learner_activities.go
@@ -150,7 +150,7 @@ If there are no meaningful lessons, return an empty array [].`,
 		if first := extractFirstCompleteJSONObject(jsonStr); first != "" {
 			wrapped := "[" + first + "]"
 			if err3 := json.Unmarshal([]byte(wrapped), &lessons); err3 == nil {
-				logger.Info(OctopusPrefix+" Recovered 1 lesson from partial JSON array")
+				logger.Info(OctopusPrefix + " Recovered 1 lesson from partial JSON array")
 				goto stamped
 			}
 		}
@@ -320,7 +320,6 @@ rules:
 
 	return rules, nil
 }
-
 
 // SynthesizeCLAUDEmdActivity reads ALL accumulated lessons from the knowledge base,
 // deduplicates and groups by category, and writes a CLAUDE.md file to the project root.
@@ -667,4 +666,3 @@ func (a *Activities) CommitAndPushLearnerOutputsActivity(ctx context.Context, wo
 	logger.Info(OctopusPrefix + " Learner outputs committed and pushed successfully")
 	return nil
 }
-

--- a/internal/temporal/planning_workflow.go
+++ b/internal/temporal/planning_workflow.go
@@ -352,7 +352,7 @@ func PlanningCeremonyWorkflow(ctx workflow.Context, req PlanningRequest) (*TaskR
 				StateHash:  selectionStateHash,
 				ActionHash: selectionActionHash,
 				Reason:     gate.Code,
-					Metadata:   fmt.Sprintf(`{"message":%q}`, gate.Message),
+				Metadata:   fmt.Sprintf(`{"message":%q}`, gate.Message),
 			})
 			reviewAndProposeAlternatives(ctx, req, graph, branchID, "selection_"+gate.Code, selectedID, rankedCandidates, candidateScoreAdjustments)
 			handlePlanningGateFailure(ctx, req, graph, branchID, "selection", gate, selectedID, selectionStateHash, selectionActionHash)
@@ -517,7 +517,7 @@ func PlanningCeremonyWorkflow(ctx workflow.Context, req PlanningRequest) (*TaskR
 				StateHash:  questionsStateHash,
 				ActionHash: questionsActionHash,
 				Reason:     gate.Code,
-					Metadata:   fmt.Sprintf(`{"message":%q}`, gate.Message),
+				Metadata:   fmt.Sprintf(`{"message":%q}`, gate.Message),
 			})
 			recordPlanningSnapshot(ctx, req, PlanningSnapshotRecord{
 				Project:   req.Project,
@@ -671,7 +671,7 @@ func PlanningCeremonyWorkflow(ctx workflow.Context, req PlanningRequest) (*TaskR
 				StateHash:  stateHash,
 				ActionHash: actionHash,
 				Reason:     gate.Code,
-					Metadata:   fmt.Sprintf(`{"message":%q}`, gate.Message),
+				Metadata:   fmt.Sprintf(`{"message":%q}`, gate.Message),
 			})
 			recordPlanningSnapshot(ctx, req, PlanningSnapshotRecord{
 				Project:   req.Project,
@@ -1219,7 +1219,7 @@ func handlePlanningGateFailure(
 		SummaryText:    gate.Code,
 		FullText:       gate.Message,
 		Reward:         0,
-			MetadataJSON:   fmt.Sprintf(`{"code":%q,"message":%q}`, gate.Code, gate.Message),
+		MetadataJSON:   fmt.Sprintf(`{"code":%q,"message":%q}`, gate.Code, gate.Message),
 		SelectedOption: "",
 	})
 	rollbackPlanningState(ctx, req, graph, branchID, gate.Code)

--- a/internal/temporal/protein_activities.go
+++ b/internal/temporal/protein_activities.go
@@ -132,13 +132,13 @@ func (a *Activities) MoleculeRetroActivity(ctx context.Context, req MoleculeRetr
 
 // MoleculeRetroRequest contains inputs for a retro analysis.
 type MoleculeRetroRequest struct {
-	ProteinID    string `json:"protein_id"`
-	MorselID     string `json:"morsel_id"`
-	DoDPassed    bool   `json:"dod_passed"`
-	BuildPassed  bool   `json:"build_passed"`
-	UBSCritical  int    `json:"ubs_critical"`
-	AttemptCount int    `json:"attempt_count"`
-	TokensUsed   int    `json:"tokens_used"`
+	ProteinID    string  `json:"protein_id"`
+	MorselID     string  `json:"morsel_id"`
+	DoDPassed    bool    `json:"dod_passed"`
+	BuildPassed  bool    `json:"build_passed"`
+	UBSCritical  int     `json:"ubs_critical"`
+	AttemptCount int     `json:"attempt_count"`
+	TokensUsed   int     `json:"tokens_used"`
 	DurationS    float64 `json:"duration_s"`
 }
 

--- a/internal/temporal/sentinel_activities.go
+++ b/internal/temporal/sentinel_activities.go
@@ -93,13 +93,13 @@ func (a *Activities) SentinelScanActivity(ctx context.Context, req SentinelScanR
 
 	if !buildBroken {
 		// Out-of-scope but build still passes — warn but allow
-		logger.Info(SharkPrefix+" Sentinel: out-of-scope files found but build OK, allowing")
+		logger.Info(SharkPrefix + " Sentinel: out-of-scope files found but build OK, allowing")
 		result.Passed = true
 		return result, nil
 	}
 
 	// 5. Build is broken — revert out-of-scope files and re-check
-	logger.Warn(SharkPrefix+" Sentinel: build broken with out-of-scope changes, reverting")
+	logger.Warn(SharkPrefix + " Sentinel: build broken with out-of-scope changes, reverting")
 	for _, f := range result.OutOfScopeFiles {
 		revertCmd := exec.CommandContext(ctx, "git", "checkout", "main", "--", f)
 		revertCmd.Dir = workDir

--- a/internal/temporal/worker.go
+++ b/internal/temporal/worker.go
@@ -198,9 +198,9 @@ func StartWorker(st *store.Store, tiers config.Tiers, dag *graph.DAG, cfgMgr con
 	// Single-stage planning replaces the old 3-agent ceremony.
 	w.RegisterWorkflow(AutonomousPlanningCeremonyWorkflow)
 	w.RegisterActivity(acts.TurtlePlanArtifactActivity)
-	w.RegisterActivity(acts.TurtleExploreActivity)     // deprecated but kept for running workflows
-	w.RegisterActivity(acts.TurtleDeliberateActivity)   // deprecated but kept for running workflows
-	w.RegisterActivity(acts.TurtleConvergeActivity)     // deprecated but kept for running workflows
+	w.RegisterActivity(acts.TurtleExploreActivity)    // deprecated but kept for running workflows
+	w.RegisterActivity(acts.TurtleDeliberateActivity) // deprecated but kept for running workflows
+	w.RegisterActivity(acts.TurtleConvergeActivity)   // deprecated but kept for running workflows
 	w.RegisterActivity(acts.TurtleDecomposeActivity)
 	w.RegisterActivity(acts.TurtleEmitActivity)
 	w.RegisterActivity(acts.TurtleSendAsActivity)

--- a/internal/temporal/workflow.go
+++ b/internal/temporal/workflow.go
@@ -609,8 +609,8 @@ func ChumAgentWorkflow(ctx workflow.Context, req TaskRequest) (err error) {
 				closeCtx := workflow.WithActivityOptions(ctx, recordOpts)
 				_ = workflow.ExecuteActivity(closeCtx, a.CloseTaskActivity, req.TaskID, "completed").Get(ctx, nil)
 
-					recordOutcome(ctx, recordOpts, a, req, "completed", 0,
-						true, "", startTime, totalTokens, activityTokens, stepMetrics)
+				recordOutcome(ctx, recordOpts, a, req, "completed", 0,
+					true, "", startTime, totalTokens, activityTokens, stepMetrics)
 
 				// ===== CHUM LOOP — spawn async learner + groomer =====
 				spawnCHUMWorkflows(ctx, logger, req, plan, baseWorkDir)
@@ -814,8 +814,8 @@ func ChumAgentWorkflow(ctx workflow.Context, req TaskRequest) (err error) {
 			}
 		}
 
-			// If triage said rescope, skip remaining tiers entirely
-			if rescopeTriggered {
+		// If triage said rescope, skip remaining tiers entirely
+		if rescopeTriggered {
 			logger.Info(SharkPrefix+" Triage rescope — skipping remaining tiers",
 				"Reason", rescopeReason)
 			break
@@ -891,16 +891,16 @@ func recordOutcome(ctx workflow.Context, opts workflow.ActivityOptions, a *Activ
 		Provider:       req.Provider,
 		Status:         status,
 		ExitCode:       exitCode,
-			DurationS:      duration,
-			DoDPassed:      dodPassed,
-			DoDFailures:    dodFailures,
-			Handoffs:       0,
-			TotalTokens:    tokens,
-			ActivityTokens: activityTokens,
-			StepMetrics:    steps,
-		}).Get(ctx, nil); err != nil {
-			logger.Warn(SharkPrefix+" RecordOutcome activity failed (best-effort)", "error", err)
-		}
+		DurationS:      duration,
+		DoDPassed:      dodPassed,
+		DoDFailures:    dodFailures,
+		Handoffs:       0,
+		TotalTokens:    tokens,
+		ActivityTokens: activityTokens,
+		StepMetrics:    steps,
+	}).Get(ctx, nil); err != nil {
+		logger.Warn(SharkPrefix+" RecordOutcome activity failed (best-effort)", "error", err)
+	}
 }
 
 // recordOrganismLog is a fire-and-forget helper to persist organism logs from

--- a/internal/temporal/workflow_dispatcher.go
+++ b/internal/temporal/workflow_dispatcher.go
@@ -661,10 +661,11 @@ func listOpenAgentWorkflows(ctx context.Context, tc workflowListClient, project 
 	return listOpenAgentWorkflowsForAgent(ctx, tc, project, "")
 }
 
-//nolint:unused // Reserved for follow-up dispatch de-duplication against explosion workflows.
 // listOpenExplosionWorkflows returns all currently running CambrianExplosionWorkflow
 // instances. The dispatcher must check these to prevent re-dispatching tasks that
 // already have an in-flight explosion (which spawns child ChumAgentWorkflows).
+//
+//nolint:unused // Reserved for follow-up dispatch de-duplication against explosion workflows.
 func listOpenExplosionWorkflows(ctx context.Context, tc workflowListClient) ([]openWorkflowExecution, error) {
 	query := "WorkflowType = 'CambrianExplosionWorkflow' AND ExecutionStatus = 'Running'"
 
@@ -767,10 +768,11 @@ func buildOpenAgentWorkflowQueryForAgent(project, agent string) string {
 	return ChumAgentRunningVisibilityQueryForProjectAndAgent(project, agent)
 }
 
-//nolint:unused // Reserved for follow-up dispatch de-duplication against recently completed workflows.
 // listRecentlyCompletedWorkflows returns IDs of ChumAgentWorkflows that
 // completed in the last 24 hours. The dispatcher skips these to avoid
 // re-dispatching tasks that already succeeded.
+//
+//nolint:unused // Reserved for follow-up dispatch de-duplication against recently completed workflows.
 func listRecentlyCompletedWorkflows(ctx context.Context, tc workflowListClient) (map[string]struct{}, error) {
 	cutoff := time.Now().Add(-24 * time.Hour).Format(time.RFC3339)
 	query := fmt.Sprintf(

--- a/internal/temporal/workflow_explosion.go
+++ b/internal/temporal/workflow_explosion.go
@@ -135,17 +135,17 @@ func CambrianExplosionWorkflow(ctx workflow.Context, req TaskRequest, providers 
 				allFailures = append(allFailures, fmt.Sprintf("%s: %s", res.Provider, res.Error))
 			}
 		}
-			if err := workflow.ExecuteActivity(recordCtx, a.EscalateActivity, req.TaskID, allFailures).Get(ctx, nil); err != nil {
-				logger.Warn(SharkPrefix+" Failed to record escalation in explosion workflow", "error", err)
-			}
+		if err := workflow.ExecuteActivity(recordCtx, a.EscalateActivity, req.TaskID, allFailures).Get(ctx, nil); err != nil {
+			logger.Warn(SharkPrefix+" Failed to record escalation in explosion workflow", "error", err)
+		}
 
 		// Clean up all worktrees
 		for _, res := range results {
 			resDir := WorktreeDir(req.TaskID, res.ExplosionID)
-				if err := workflow.ExecuteActivity(recordCtx, a.CleanupWorktreeActivity, req.WorkDir, resDir).Get(ctx, nil); err != nil {
-					logger.Warn(SharkPrefix+" Failed cleanup worktree after explosion extinction", "error", err, "workdir", resDir)
-				}
+			if err := workflow.ExecuteActivity(recordCtx, a.CleanupWorktreeActivity, req.WorkDir, resDir).Get(ctx, nil); err != nil {
+				logger.Warn(SharkPrefix+" Failed cleanup worktree after explosion extinction", "error", err, "workdir", resDir)
 			}
+		}
 		recordOrganismLog(ctx, "explosion", req.TaskID, req.Project, "failed",
 			fmt.Sprintf("all %d providers extinct", len(results)),
 			startTime, len(results), "all providers failed")

--- a/internal/temporal/workflow_test.go
+++ b/internal/temporal/workflow_test.go
@@ -906,11 +906,11 @@ func TestStepDurationLoggingEscalation(t *testing.T) {
 	}).Return(nil)
 
 	env.ExecuteWorkflow(ChumAgentWorkflow, TaskRequest{
-		TaskID:           "test-morsel-escalate",
-		Project:          "test-project",
-		Prompt:           "will fail dod",
-		Agent:            "claude",
-		WorkDir:          "/tmp/test",
+		TaskID:             "test-morsel-escalate",
+		Project:            "test-project",
+		Prompt:             "will fail dod",
+		Agent:              "claude",
+		WorkDir:            "/tmp/test",
 		MaxRetriesOverride: 1,
 	})
 


### PR DESCRIPTION
Fixes formatting issues detected by `gofmt` across graph, store, and temporal packages.

## Changes

Applied `gofmt -w .` to fix formatting in 19 files:
- `internal/graph/task.go`
- `internal/store/{genomes,metrics,trace}.go`
- `internal/temporal/*.go` (16 files)

Changes are **purely whitespace/indentation** with no functional modifications.

## Testing

✅ `go build ./...` - PASS  
✅ `go vet ./...` - PASS  
✅ `gofmt -l .` - No remaining issues  
✅ Pre-commit checks - PASS

## Impact

Resolves pre-existing CI lint failures that were blocking PR merges.