### PR TITLE
fix: use consistent 'canceled' spelling in SQL queries

### DIFF
--- a/internal/store/dispatches.go
+++ b/internal/store/dispatches.go
@@ -299,7 +299,7 @@ func (s *Store) WasMorselAgentDispatchedRecently(morselID, agentID string, coold
 		FROM dispatches 
 		WHERE morsel_id = ?
 		  AND dispatched_at > ?
-		  AND status IN ('running', 'completed', 'failed', 'cancelled', 'interrupted', 'pending_retry', 'retried')`,
+		  AND status IN ('running', 'completed', 'failed', 'canceled', 'interrupted', 'pending_retry', 'retried')`,
 			morselID, cutoff.Format(time.DateTime),
 		).Scan(&count)
 	} else {
@@ -309,7 +309,7 @@ func (s *Store) WasMorselAgentDispatchedRecently(morselID, agentID string, coold
 		WHERE morsel_id = ?
 		  AND agent_id = ?
 		  AND dispatched_at > ?
-		  AND status IN ('running', 'completed', 'failed', 'cancelled', 'interrupted', 'pending_retry', 'retried')`,
+		  AND status IN ('running', 'completed', 'failed', 'canceled', 'interrupted', 'pending_retry', 'retried')`,
 			morselID, agentID, cutoff.Format(time.DateTime),
 		).Scan(&count)
 	}
@@ -334,7 +334,7 @@ func (s *Store) HasRecentConsecutiveFailures(morselID string, threshold int, win
 		FROM dispatches
 		WHERE morsel_id = ?
 		  AND dispatched_at > ?
-		  AND status IN ('failed', 'completed', 'cancelled', 'interrupted', 'retried', 'pending_retry', 'running')
+		  AND status IN ('failed', 'completed', 'canceled', 'interrupted', 'retried', 'pending_retry', 'running')
 		ORDER BY dispatched_at DESC
 		LIMIT ?`,
 		morselID, cutoff, threshold,


### PR DESCRIPTION
Fixes test failure in `TestHasRecentConsecutiveFailures_IncludesFailureLikeStatuses`.

## Problem

The test was failing because of inconsistent spelling of "canceled" vs "cancelled":

**American spelling** (one 'l') - used in:
- Code comments (`Stage` field documentation)
- Go code (`isFailureStatusForQuarantine` function)  
- Test assertions

**British spelling** (two 'l's) - used in:
- SQL queries ❌

This caused status value mismatches where dispatches with status `"canceled"` weren't matched by SQL queries looking for `'cancelled'`.

## Solution

Changed 3 SQL queries to use `'canceled'` for consistency:
- `WasMorselAgentDispatchedRecently` (2 queries)
- `HasRecentConsecutiveFailures` (1 query)

## Testing

✅ `TestHasRecentConsecutiveFailures_IncludesFailureLikeStatuses` - PASS  
✅ All store tests - PASS  
✅ `go build ./...` - PASS  
✅ `go vet ./...` - PASS

## Impact

Resolves pre-existing CI test failure that was blocking PR merges.