### PR TITLE
chore: enable Crab decomposition

### DIFF
--- a/chum.toml
+++ b/chum.toml
@@ -246,7 +246,7 @@ max_concurrent_per_project = 3
 enabled = false
 
 [crab]
-enabled = false
+enabled = true
 
 [calcifier]
 enabled = false


### PR DESCRIPTION
Enables Crab to decompose open tasks into ready morsels. Uses flash tier (free API key).