### PR TITLE
fix: check for git remote before pushing worktree

### DIFF
--- a/internal/temporal/activities.go
+++ b/internal/temporal/activities.go
@@ -1088,6 +1088,14 @@ func (a *Activities) PushWorktreeActivity(ctx context.Context, wtDir string) err
 	logger := activity.GetLogger(ctx)
 	logger.Info(SharkPrefix+" Pushing worktree branch to remote", "worktree", wtDir)
 
+	// Check if origin remote exists before attempting push
+	checkCmd := exec.CommandContext(ctx, "git", "remote", "get-url", "origin")
+	checkCmd.Dir = wtDir
+	if out, err := checkCmd.CombinedOutput(); err != nil {
+		logger.Warn(SharkPrefix+" No origin remote configured, skipping push", "worktree", wtDir, "error", string(out))
+		return fmt.Errorf("no origin remote configured in worktree (non-fatal): %w", err)
+	}
+
 	pushCmd := exec.CommandContext(ctx, "git", "push", "origin", "HEAD")
 	pushCmd.Dir = wtDir
 	if out, err := pushCmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Summary
Adds a preemptive check for origin remote existence before attempting to push worktree branches.

## Changes
- Check if origin remote exists using `git remote get-url origin`
- Return early with clear error message if remote is not configured
- Prevents crash scenarios in worktrees without remote setup

## Why
Worktrees created in certain scenarios (testing, local development) may not have an origin remote configured. Attempting to push in these cases results in confusing errors. This change makes the failure mode explicit and non-fatal.

## Testing
- Verified error handling path with missing remote
- Confirmed normal push flow still works when remote exists

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>