### PR TITLE
fix: allow starting with no projects enabled (idle mode)

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -292,8 +292,8 @@ priority = 1
 `
 	path := writeTestConfig(t, cfg)
 	_, err := Load(path)
-	if err == nil {
-		t.Fatal("expected error for no enabled projects")
+	if err != nil {
+		t.Fatalf("idle mode (no enabled projects) should be valid, got: %v", err)
 	}
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -30,12 +30,8 @@ func validate(cfg *Config) error {
 		}
 	}
 
-	hasEnabled := false
 	for projectName := range cfg.Projects {
 		p := cfg.Projects[projectName]
-		if p.Enabled {
-			hasEnabled = true
-		}
 
 		// Validate sprint planning configuration when provided
 		if err := validateSprintPlanningConfig(projectName, p); err != nil {
@@ -53,9 +49,8 @@ func validate(cfg *Config) error {
 			return fmt.Errorf("project %q merge config: %w", projectName, err)
 		}
 	}
-	if !hasEnabled {
-		return fmt.Errorf("at least one project must be enabled")
-	}
+	// Allow starting with no projects enabled (idle mode).
+	// The dispatcher will simply have nothing to do.
 
 	if err := validateCadenceConfig(cfg.Cadence); err != nil {
 		return fmt.Errorf("cadence config: %w", err)


### PR DESCRIPTION
## Summary
- Remove hard validation error requiring at least one enabled project
- Allows chum service to start and run idle while all projects/workflows are paused during CHUM port
- Update test to assert idle mode is valid

## Test plan
- [x] `go test ./internal/config/...` passes
- [x] `golangci-lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)